### PR TITLE
Add styling for indeterminate checkbox state

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -220,7 +220,7 @@ impose any opinions in that regard. Here we've used flexbox to center the checkb
       </div>
       <div>
         <label class="inline-flex items-center">
-          <input type="checkbox" class="form-checkbox">
+          <input type="checkbox" class="form-checkbox" indeterminate>
           <span class="ml-2">Option 3</span>
         </label>
       </div>

--- a/src/defaultOptions.js
+++ b/src/defaultOptions.js
@@ -130,6 +130,14 @@ module.exports = {
       backgroundPosition: 'center',
       backgroundRepeat: 'no-repeat',
     },
+    '&[indeterminate]': {
+      borderColor: 'transparent',
+      backgroundColor: 'currentColor',
+      backgroundSize: '100% 100%',
+      backgroundPosition: 'center',
+      backgroundRepeat: 'no-repeat',
+      icon: iconColor => `<svg fill="${iconColor}" viewBox="0 0 24 26" xmlns="http://www.w3.org/2000/svg"><path d="M18,11H6c-1.104,0-2,0.896-2,2s0.896,2,2,2h12c1.104,0,2-0.896,2-2S19.104,11,18,11z"/></svg>`,
+    },
   },
   radio: {
     appearance: 'none',

--- a/src/index.js
+++ b/src/index.js
@@ -121,6 +121,9 @@ module.exports = function ({ addUtilities, addComponents, theme, postcss }) {
       return {
         '&:checked': {
           backgroundImage: `url("${svgToDataUri(isFunction(icon) ? icon(iconColor) : icon)}")`
+        },
+        '&[indeterminate]': {
+          backgroundImage: `url("${svgToDataUri(isFunction(icon) ? icon(iconColor) : icon)}")`
         }
       }
     }))


### PR DESCRIPTION
Checkboxes can have an `indeterminate` state as described here:

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox

Default browser behavior is rendering a minus symbol in the checkbox. This PR implements an SVG minus symbol icon for checkboxes with the `indeterminate` attribute.

