### PR TITLE
Styling labels

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -57,7 +57,7 @@ module.exports = {
 ### 3. Style some forms
 
 The plugin will generate a handful of new classes that you can use to style your forms:
-`form-input`, `form-textarea`, `form-select`, `form-multiselect`, `form-checkbox`, and `form-radio`.
+`form-label`, `form-input`, `form-textarea`, `form-select`, `form-multiselect`, `form-checkbox`, and `form-radio`.
 
 Simply add those classes to the corresponding HTML elements to apply some sensible default form
 styles that look the same in all browsers, and are easy to tweak with utilities:
@@ -134,6 +134,17 @@ styles that look the same in all browsers, and are easy to tweak with utilities:
     </div>
   </div>
 </CodeSample>
+
+---
+
+## Form Label
+
+Add basic styles to a normal `label` element using the `form-label` class.
+
+<CodeSample code={`
+  <label class="form-label" for="my-control">Styled label</label>
+  <input type="email" id="my-control" class="form-input mt-1 block w-full" placeholder="john@example.com">
+`}/>
 
 ---
 

--- a/src/defaultOptions.js
+++ b/src/defaultOptions.js
@@ -1,6 +1,9 @@
 const defaultTheme = require('tailwindcss/resolveConfig')(require('tailwindcss/defaultConfig')).theme
 
 module.exports = {
+  label: {
+    fontSize: defaultTheme.fontSize.base,
+  },
   input: {
     appearance: 'none',
     backgroundColor: defaultTheme.colors.white,

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,14 @@ function replaceIconDeclarations(component, replace) {
 }
 
 module.exports = function ({ addUtilities, addComponents, theme, postcss }) {
+  function addLabel(options, modifier = '') {
+    if (isEmpty(options)) {
+      return
+    }
+
+    addComponents({ [`.form-label{modifier}`]: options })
+  }
+  
   function addInput(options, modifier = '') {
     if (isEmpty(options)) {
       return
@@ -153,6 +161,7 @@ module.exports = function ({ addUtilities, addComponents, theme, postcss }) {
   function registerComponents() {
     const options = resolveOptions(theme('customForms'))
 
+    addLabel(options.default.label)
     addInput(options.default.input)
     addTextarea(options.default.textarea)
     addMultiselect(options.default.multiselect)
@@ -163,6 +172,7 @@ module.exports = function ({ addUtilities, addComponents, theme, postcss }) {
     Object.keys((({ default: _default, ...rest }) => rest)(options)).forEach(key => {
       const modifier = `-${key}`
 
+      addLabel(options[key].label || {}, modifier)
       addInput(options[key].input || {}, modifier)
       addTextarea(options[key].textarea || {}, modifier)
       addMultiselect(options[key].multiselect || {}, modifier)


### PR DESCRIPTION
This PR adds `.form-label` class to apply to form labels. It helps to style more form components in the same way via `tailwind.config.js`.

With this PR you can style labels like this
```javascript
module.exports = {
    purge: [
        './resources/views/**/*.blade.php',
        './resources/js/**/*.vue',
    ],
    theme: {
        extend: {},
        customForms: theme => ({
            default: {
                label: {
                    fontSize: theme('fontSize.xs'),
                    letterSpacing: theme('letterSpacing.wide'),
                    textTransform: 'uppercase'
                }
            }
        })
    },
    variants: {},
    plugins: [
        require('@tailwindcss/custom-forms')
    ]
}

```