### PR TITLE
Implement indeterminate icon for checkboxes

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -251,7 +251,7 @@ color utilities, like `text-indigo-600`.
       </div>
       <div>
         <label class="inline-flex items-center">
-          <input type="checkbox" class="form-checkbox text-pink-600">
+          <input type="checkbox" class="form-checkbox text-pink-600" checked>
           <span class="ml-2">Option 3</span>
         </label>
       </div>

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -509,10 +509,6 @@ module.exports = {
 Checkbox and radio icons are automatically hidden unless the elements are `:checked`, so you don't
 need to include that pseudo-selector in your configuration when using the special `icon` property.
 
-
-
-
-
 #### Customizing the icon color
 
 If you are happy with the default icons and just want to customize the color, you can use the

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -220,7 +220,7 @@ impose any opinions in that regard. Here we've used flexbox to center the checkb
       </div>
       <div>
         <label class="inline-flex items-center">
-          <input type="checkbox" class="form-checkbox">
+          <input type="checkbox" class="form-checkbox" indeterminate>
           <span class="ml-2">Option 3</span>
         </label>
       </div>
@@ -251,7 +251,7 @@ color utilities, like `text-indigo-600`.
       </div>
       <div>
         <label class="inline-flex items-center">
-          <input type="checkbox" class="form-checkbox text-pink-600" checked>
+          <input type="checkbox" class="form-checkbox text-pink-600">
           <span class="ml-2">Option 3</span>
         </label>
       </div>
@@ -462,6 +462,26 @@ module.exports = {
 }
 ```
 
+You can also customize the [indeterminate state](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate) icon for a checkbox using the special `indeterminateIcon` property.
+
+```js
+// tailwind.config.js
+module.exports = {
+  theme: {
+    customForms: theme => ({
+      default: {
+        checkbox: {
+          indeterminateIcon: '<svg fill="#1a202c" viewBox="0 0 24 26" xmlns="http://www.w3.org/2000/svg"><path d="M18,11H6c-1.104,0-2,0.896-2,2s0.896,2,2,2h12c1.104,0,2-0.896,2-2S19.104,11,18,11z"/></svg>'
+        },
+      },
+    })
+  },
+  plugins: [
+    require('@tailwindcss/custom-forms'),
+  ]
+}
+```
+
 You can also switch to a different icon for different states, like if you wanted to change the
 checkmark on hover:
 
@@ -488,6 +508,10 @@ module.exports = {
 
 Checkbox and radio icons are automatically hidden unless the elements are `:checked`, so you don't
 need to include that pseudo-selector in your configuration when using the special `icon` property.
+
+
+
+
 
 #### Customizing the icon color
 

--- a/src/defaultOptions.js
+++ b/src/defaultOptions.js
@@ -133,6 +133,8 @@ module.exports = (theme) => ({
     iconColor: theme('colors.white', colors.white),
     icon: (iconColor) =>
       `<svg viewBox="0 0 16 16" fill="${iconColor}" xmlns="http://www.w3.org/2000/svg"><path d="M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z"/></svg>`,
+    indeterminateIcon: (iconColor) =>
+      `<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path stroke="${iconColor}" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h8"/></svg>`,
     '&:focus': {
       outline: 'none',
       '--ring-offset-shadow': `0 0 0 var(--ring-offset-width, 2px) var(--ring-offset-color, #fff)`,
@@ -156,6 +158,13 @@ module.exports = (theme) => ({
     '&:checked:focus': {
       borderColor: 'transparent',
       backgroundColor: 'currentColor',
+    },
+    '&[indeterminate]': {
+      borderColor: 'transparent',
+      backgroundColor: 'currentColor',
+      backgroundSize: '100% 100%',
+      backgroundPosition: 'center',
+      backgroundRepeat: 'no-repeat',
     },
   },
   radio: {

--- a/src/index.js
+++ b/src/index.js
@@ -15,8 +15,8 @@ function replaceIconDeclarations(component, replace) {
     if (!isPlainObject(value)) return
 
     if (Object.keys(value).some((prop) => properties.includes(prop))) {
-      const { iconColor, icon, ...rest } = value
-      this.update(merge(replace({ icon, iconColor }), rest))
+      const { iconColor, icon, indeterminateIcon, ...rest } = value
+      this.update(merge(replace({ icon, indeterminateIcon, iconColor }), rest))
     }
   })
 }
@@ -46,11 +46,19 @@ module.exports = plugin(
       },
       checkbox(options, modifier) {
         addComponents(
-          replaceIconDeclarations({ [`.form-checkbox${modifier}`]: options }, ({ icon, iconColor }) => ({
-            '&:checked': {
-              backgroundImage: `url("${svgToDataUri(isFunction(icon) ? icon(iconColor) : icon)}")`,
-            },
-          }))
+          replaceIconDeclarations(
+            { [`.form-checkbox${modifier}`]: options },
+            ({ icon, indeterminateIcon, iconColor }) => ({
+              '&:checked': {
+                backgroundImage: `url("${svgToDataUri(isFunction(icon) ? icon(iconColor) : icon)}")`,
+              },
+              '&[indeterminate]': {
+                backgroundImage: `url("${svgToDataUri(
+                  isFunction(indeterminateIcon) ? indeterminateIcon(iconColor) : indeterminateIcon
+                )}")`,
+              },
+            })
+          )
         )
       },
       radio(options, modifier) {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -49,7 +49,9 @@ it('should generate the default classes for the form components', async () => {
 
     .form-input:focus {
       outline: none;
-      box-shadow: 0 0 0 var(--ring-offset-width, 0) var(--ring-offset-color, #fff), 0 0 0 calc(1px + var(--ring-offset-width, 0px)) var(--ring-color, #2563eb), var(--box-shadow, 0 0 #0000);
+      --ring-offset-shadow: 0 0 0 var(--ring-offset-width, 0) var(--ring-offset-color, #fff);
+      --ring-shadow: 0 0 0 calc(1px + var(--ring-offset-width, 0px)) var(--ring-color, #2563eb);
+      box-shadow: var(--ring-offset-shadow), var(--ring-shadow), var(--box-shadow, 0 0 #0000);
       border-color: #2563eb;
     }
 
@@ -74,7 +76,9 @@ it('should generate the default classes for the form components', async () => {
 
     .form-textarea:focus {
       outline: none;
-      box-shadow: 0 0 0 var(--ring-offset-width, 0) var(--ring-offset-color, #fff), 0 0 0 calc(1px + var(--ring-offset-width, 0px)) var(--ring-color, #2563eb), var(--box-shadow, 0 0 #0000);
+      --ring-offset-shadow: 0 0 0 var(--ring-offset-width, 0) var(--ring-offset-color, #fff);
+      --ring-shadow: 0 0 0 calc(1px + var(--ring-offset-width, 0px)) var(--ring-color, #2563eb);
+      box-shadow: var(--ring-offset-shadow), var(--ring-shadow), var(--box-shadow, 0 0 #0000);
       border-color: #2563eb;
     }
 
@@ -94,7 +98,9 @@ it('should generate the default classes for the form components', async () => {
 
     .form-multiselect:focus {
       outline: none;
-      box-shadow: 0 0 0 var(--ring-offset-width, 0) var(--ring-offset-color, #fff), 0 0 0 calc(1px + var(--ring-offset-width, 0px)) var(--ring-color, #2563eb), var(--box-shadow, 0 0 #0000);
+      --ring-offset-shadow: 0 0 0 var(--ring-offset-width, 0) var(--ring-offset-color, #fff);
+      --ring-shadow: 0 0 0 calc(1px + var(--ring-offset-width, 0px)) var(--ring-color, #2563eb);
+      box-shadow: var(--ring-offset-shadow), var(--ring-shadow), var(--box-shadow, 0 0 #0000);
       border-color: #2563eb;
     }
 
@@ -119,12 +125,23 @@ it('should generate the default classes for the form components', async () => {
 
     .form-select:focus {
       outline: none;
-      box-shadow: 0 0 0 var(--ring-offset-width, 0) var(--ring-offset-color, #fff), 0 0 0 calc(1px + var(--ring-offset-width, 0px)) var(--ring-color, #2563eb), var(--box-shadow, 0 0 #0000);
+      --ring-offset-shadow: 0 0 0 var(--ring-offset-width, 0) var(--ring-offset-color, #fff);
+      --ring-shadow: 0 0 0 calc(1px + var(--ring-offset-width, 0px)) var(--ring-color, #2563eb);
+      box-shadow: var(--ring-offset-shadow), var(--ring-shadow), var(--box-shadow, 0 0 #0000);
       border-color: #2563eb;
     }
 
     .form-checkbox:checked {
       background-image: url(\\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e\\");
+      border-color: transparent;
+      background-color: currentColor;
+      background-size: 100% 100%;
+      background-position: center;
+      background-repeat: no-repeat;
+    }
+
+    .form-checkbox[indeterminate] {
+      background-image: url(\\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e\\");
       border-color: transparent;
       background-color: currentColor;
       background-size: 100% 100%;
@@ -151,7 +168,9 @@ it('should generate the default classes for the form components', async () => {
 
     .form-checkbox:focus {
       outline: none;
-      box-shadow: 0 0 0 var(--ring-offset-width, 2px) var(--ring-offset-color, #fff), 0 0 0 calc(2px + var(--ring-offset-width, 2px)) var(--ring-color, #2563eb), var(--box-shadow, 0 0 #0000);
+      --ring-offset-shadow: 0 0 0 var(--ring-offset-width, 2px) var(--ring-offset-color, #fff);
+      --ring-shadow: 0 0 0 calc(2px + var(--ring-offset-width, 2px)) var(--ring-color, #2563eb);
+      box-shadow: var(--ring-offset-shadow), var(--ring-shadow), var(--box-shadow, 0 0 #0000);
     }
 
     .form-checkbox:checked:hover {
@@ -192,7 +211,9 @@ it('should generate the default classes for the form components', async () => {
 
     .form-radio:focus {
       outline: none;
-      box-shadow: 0 0 0 var(--ring-offset-width, 2px) var(--ring-offset-color, #fff), 0 0 0 calc(2px + var(--ring-offset-width, 2px)) var(--ring-color, #2563eb), var(--box-shadow, 0 0 #0000);
+      --ring-offset-shadow: 0 0 0 var(--ring-offset-width, 2px) var(--ring-offset-color, #fff);
+      --ring-shadow: 0 0 0 calc(2px + var(--ring-offset-width, 2px)) var(--ring-color, #2563eb);
+      box-shadow: var(--ring-offset-shadow), var(--ring-shadow), var(--box-shadow, 0 0 #0000);
     }
 
     .form-radio:checked:hover {
@@ -271,7 +292,9 @@ it('should be possible to remove the `input` component', async () => {
       -
       - .form-input:focus {
       -   outline: none;
-      -   box-shadow: 0 0 0 var(--ring-offset-width, 0) var(--ring-offset-color, #fff), 0 0 0 calc(1px + var(--ring-offset-width, 0px)) var(--ring-color, #2563eb), var(--box-shadow, 0 0 #0000);
+      -   --ring-offset-shadow: 0 0 0 var(--ring-offset-width, 0) var(--ring-offset-color, #fff);
+      -   --ring-shadow: 0 0 0 calc(1px + var(--ring-offset-width, 0px)) var(--ring-color, #2563eb);
+      -   box-shadow: var(--ring-offset-shadow), var(--ring-shadow), var(--box-shadow, 0 0 #0000);
       -   border-color: #2563eb;
       - }
       -
@@ -319,7 +342,9 @@ it('should be possible to remove the `textarea` component', async () => {
       -
       - .form-textarea:focus {
       -   outline: none;
-      -   box-shadow: 0 0 0 var(--ring-offset-width, 0) var(--ring-offset-color, #fff), 0 0 0 calc(1px + var(--ring-offset-width, 0px)) var(--ring-color, #2563eb), var(--box-shadow, 0 0 #0000);
+      -   --ring-offset-shadow: 0 0 0 var(--ring-offset-width, 0) var(--ring-offset-color, #fff);
+      -   --ring-shadow: 0 0 0 calc(1px + var(--ring-offset-width, 0px)) var(--ring-color, #2563eb);
+      -   box-shadow: var(--ring-offset-shadow), var(--ring-shadow), var(--box-shadow, 0 0 #0000);
       -   border-color: #2563eb;
       - }
       -
@@ -362,7 +387,9 @@ it('should be possible to remove the `multiselect` component', async () => {
       -
       - .form-multiselect:focus {
       -   outline: none;
-      -   box-shadow: 0 0 0 var(--ring-offset-width, 0) var(--ring-offset-color, #fff), 0 0 0 calc(1px + var(--ring-offset-width, 0px)) var(--ring-color, #2563eb), var(--box-shadow, 0 0 #0000);
+      -   --ring-offset-shadow: 0 0 0 var(--ring-offset-width, 0) var(--ring-offset-color, #fff);
+      -   --ring-shadow: 0 0 0 calc(1px + var(--ring-offset-width, 0px)) var(--ring-color, #2563eb);
+      -   box-shadow: var(--ring-offset-shadow), var(--ring-shadow), var(--box-shadow, 0 0 #0000);
       -   border-color: #2563eb;
       - }
       -
@@ -410,7 +437,9 @@ it('should be possible to remove the `select` component', async () => {
       -
       - .form-select:focus {
       -   outline: none;
-      -   box-shadow: 0 0 0 var(--ring-offset-width, 0) var(--ring-offset-color, #fff), 0 0 0 calc(1px + var(--ring-offset-width, 0px)) var(--ring-color, #2563eb), var(--box-shadow, 0 0 #0000);
+      -   --ring-offset-shadow: 0 0 0 var(--ring-offset-width, 0) var(--ring-offset-color, #fff);
+      -   --ring-shadow: 0 0 0 calc(1px + var(--ring-offset-width, 0px)) var(--ring-color, #2563eb);
+      -   box-shadow: var(--ring-offset-shadow), var(--ring-shadow), var(--box-shadow, 0 0 #0000);
       -   border-color: #2563eb;
       - }
       -
@@ -446,6 +475,15 @@ it('should be possible to remove the `checkbox` component', async () => {
       -   background-repeat: no-repeat;
       - }
       -
+      - .form-checkbox[indeterminate] {
+      -   background-image: url('data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e');
+      -   border-color: transparent;
+      -   background-color: currentColor;
+      -   background-size: 100% 100%;
+      -   background-position: center;
+      -   background-repeat: no-repeat;
+      - }
+      -
       - .form-checkbox {
       -   appearance: none;
       -   color-adjust: exact;
@@ -465,7 +503,9 @@ it('should be possible to remove the `checkbox` component', async () => {
       -
       - .form-checkbox:focus {
       -   outline: none;
-      -   box-shadow: 0 0 0 var(--ring-offset-width, 2px) var(--ring-offset-color, #fff), 0 0 0 calc(2px + var(--ring-offset-width, 2px)) var(--ring-color, #2563eb), var(--box-shadow, 0 0 #0000);
+      -   --ring-offset-shadow: 0 0 0 var(--ring-offset-width, 2px) var(--ring-offset-color, #fff);
+      -   --ring-shadow: 0 0 0 calc(2px + var(--ring-offset-width, 2px)) var(--ring-color, #2563eb);
+      -   box-shadow: var(--ring-offset-shadow), var(--ring-shadow), var(--box-shadow, 0 0 #0000);
       - }
       -
       - .form-checkbox:checked:hover {
@@ -530,7 +570,9 @@ it('should be possible to remove the `radio` component', async () => {
       -
       - .form-radio:focus {
       -   outline: none;
-      -   box-shadow: 0 0 0 var(--ring-offset-width, 2px) var(--ring-offset-color, #fff), 0 0 0 calc(2px + var(--ring-offset-width, 2px)) var(--ring-color, #2563eb), var(--box-shadow, 0 0 #0000);
+      -   --ring-offset-shadow: 0 0 0 var(--ring-offset-width, 2px) var(--ring-offset-color, #fff);
+      -   --ring-shadow: 0 0 0 calc(2px + var(--ring-offset-width, 2px)) var(--ring-color, #2563eb);
+      -   box-shadow: var(--ring-offset-shadow), var(--ring-shadow), var(--box-shadow, 0 0 #0000);
       - }
       -
       - .form-radio:checked:hover {
@@ -915,6 +957,11 @@ it('should be possible to change the icon and icon color of a `checkbox` compone
 
       -   background-image: url('data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e');
       +   background-image: url('data:image/svg+xml,%3csvg fill='pink' /%3e');
+      
+      ---
+      
+      -   background-image: url('data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e');
+      +   background-image: url('data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='pink' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e');
 
     "
   `)
@@ -969,6 +1016,38 @@ it('should be possible to change the iconColor of a `checkbox` component', async
 
       -   background-image: url('data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e');
       +   background-image: url('data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='pink' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e');
+      
+      ---
+      
+      -   background-image: url('data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e');
+      +   background-image: url('data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='pink' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e');
+
+    "
+  `)
+})
+
+it('should be possible to change the indeterminateIcon of a `checkbox` component', async () => {
+  expect(
+    await diffOnly({
+      theme: {
+        extend: {
+          customForms: {
+            DEFAULT: {
+              css: {
+                checkbox: {
+                  indeterminateIcon: '<svg />',
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+  ).toMatchInlineSnapshot(`
+    "
+
+      -   background-image: url('data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e');
+      +   background-image: url('data:image/svg+xml,%3csvg /%3e');
 
     "
   `)
@@ -1121,6 +1200,11 @@ it('should pull values from the user config for colors', async () => {
       
       -   background-image: url('data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e');
       +   background-image: url('data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='%23WHITE' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e');
+      
+      ---
+      
+      -   background-image: url('data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e');
+      +   background-image: url('data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='%23WHITE' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e');
       
       ---
       


### PR DESCRIPTION
Adds an indeterminate state icon to checkboxes

![image](https://user-images.githubusercontent.com/56947/98757204-08880600-239a-11eb-91b2-5b42144fe82c.png)

The icon is this SVG that Adam / Steve provided: https://gist.github.com/adamwathan/77588f8c72d8f21d1022253a38a4fb03

Icon can be customized using an `indeterminateIcon` property and respects the `iconColor` customization as well.

Closes #27 Closes #62 Closes #50 (thanks for these PRs as they were a good starting point!)

