### PR TITLE
Add support for indeterminate checkboxes

### DIFF
--- a/docs/pages/demo.jsx
+++ b/docs/pages/demo.jsx
@@ -35,7 +35,7 @@ export default () => (
               </div>
               <div>
                 <label className="inline-flex items-center">
-                  <input type="checkbox" className="form-checkbox" />
+                  <input type="checkbox" className="form-checkbox" defaultChecked={true} />
                   <span className="ml-2">Option 2</span>
                 </label>
               </div>

--- a/src/defaultOptions.js
+++ b/src/defaultOptions.js
@@ -130,9 +130,6 @@ module.exports = (theme) => ({
     borderColor: theme('colors.gray.300', colors.gray[300]),
     borderWidth: borderWidth.DEFAULT,
     borderRadius: borderRadius.DEFAULT,
-    iconColor: theme('colors.white', colors.white),
-    icon: (iconColor) =>
-      `<svg viewBox="0 0 16 16" fill="${iconColor}" xmlns="http://www.w3.org/2000/svg"><path d="M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z"/></svg>`,
     '&:focus': {
       outline: 'none',
       '--ring-offset-shadow': `0 0 0 var(--ring-offset-width, 2px) var(--ring-offset-color, #fff)`,
@@ -148,12 +145,33 @@ module.exports = (theme) => ({
       backgroundSize: '100% 100%',
       backgroundPosition: 'center',
       backgroundRepeat: 'no-repeat',
+      iconColor: theme('colors.white', colors.white),
+      icon: (iconColor) =>
+        `<svg viewBox="0 0 16 16" fill="${iconColor}" xmlns="http://www.w3.org/2000/svg"><path d="M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z"/></svg>`,
     },
     '&:checked:hover': {
       borderColor: 'transparent',
       backgroundColor: 'currentColor',
     },
     '&:checked:focus': {
+      borderColor: 'transparent',
+      backgroundColor: 'currentColor',
+    },
+    '&:indeterminate': {
+      borderColor: 'transparent',
+      backgroundColor: 'currentColor',
+      backgroundSize: '100% 100%',
+      backgroundPosition: 'center',
+      backgroundRepeat: 'no-repeat',
+      iconColor: theme('colors.white', colors.white),
+      icon: (iconColor) =>
+        `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path stroke="${iconColor}" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h8"/></svg>`,
+    },
+    '&:indeterminate:hover': {
+      borderColor: 'transparent',
+      backgroundColor: 'currentColor',
+    },
+    '&:indeterminate:focus': {
       borderColor: 'transparent',
       backgroundColor: 'currentColor',
     },
@@ -173,9 +191,6 @@ module.exports = (theme) => ({
     backgroundColor: theme('colors.white', colors.white),
     borderColor: theme('colors.gray.300', colors.gray[300]),
     borderWidth: borderWidth.DEFAULT,
-    iconColor: theme('colors.white', colors.white),
-    icon: (iconColor) =>
-      `<svg viewBox="0 0 16 16" fill="${iconColor}" xmlns="http://www.w3.org/2000/svg"><circle cx="8" cy="8" r="3"/></svg>`,
     '&:focus': {
       outline: 'none',
       '--ring-offset-shadow': `0 0 0 var(--ring-offset-width, 2px) var(--ring-offset-color, #fff)`,
@@ -191,6 +206,9 @@ module.exports = (theme) => ({
       backgroundSize: '100% 100%',
       backgroundPosition: 'center',
       backgroundRepeat: 'no-repeat',
+      iconColor: theme('colors.white', colors.white),
+      icon: (iconColor) =>
+        `<svg viewBox="0 0 16 16" fill="${iconColor}" xmlns="http://www.w3.org/2000/svg"><circle cx="8" cy="8" r="3"/></svg>`,
     },
     '&:checked:hover': {
       borderColor: 'transparent',

--- a/src/index.js
+++ b/src/index.js
@@ -9,14 +9,21 @@ const defaultOptions = require('./defaultOptions')
 const svgToDataUri = require('mini-svg-data-uri')
 const traverse = require('traverse')
 
-function replaceIconDeclarations(component, replace) {
+function replaceIconDeclarations(component) {
   const properties = ['iconColor', 'icon']
   return traverse(component).map(function (value) {
     if (!isPlainObject(value)) return
 
     if (Object.keys(value).some((prop) => properties.includes(prop))) {
       const { iconColor, icon, ...rest } = value
-      this.update(merge(replace({ icon, iconColor }), rest))
+      this.update(
+        merge(
+          {
+            backgroundImage: `url("${svgToDataUri(isFunction(icon) ? icon(iconColor) : icon)}")`,
+          },
+          rest
+        )
+      )
     }
   })
 }
@@ -38,29 +45,13 @@ module.exports = plugin(
       textarea: (options, modifier) => addComponents({ [`.form-textarea${modifier}`]: options }),
       multiselect: (options, modifier) => addComponents({ [`.form-multiselect${modifier}`]: options }),
       select(options, modifier) {
-        addComponents(
-          replaceIconDeclarations({ [`.form-select${modifier}`]: options }, ({ icon, iconColor }) => ({
-            backgroundImage: `url("${svgToDataUri(isFunction(icon) ? icon(iconColor) : icon)}")`,
-          }))
-        )
+        addComponents(replaceIconDeclarations({ [`.form-select${modifier}`]: options }))
       },
       checkbox(options, modifier) {
-        addComponents(
-          replaceIconDeclarations({ [`.form-checkbox${modifier}`]: options }, ({ icon, iconColor }) => ({
-            '&:checked': {
-              backgroundImage: `url("${svgToDataUri(isFunction(icon) ? icon(iconColor) : icon)}")`,
-            },
-          }))
-        )
+        addComponents(replaceIconDeclarations({ [`.form-checkbox${modifier}`]: options }))
       },
       radio(options, modifier) {
-        addComponents(
-          replaceIconDeclarations({ [`.form-radio${modifier}`]: options }, ({ icon, iconColor }) => ({
-            '&:checked': {
-              backgroundImage: `url("${svgToDataUri(isFunction(icon) ? icon(iconColor) : icon)}")`,
-            },
-          }))
-        )
+        addComponents(replaceIconDeclarations({ [`.form-radio${modifier}`]: options }))
       },
     }
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -131,15 +131,6 @@ it('should generate the default classes for the form components', async () => {
       border-color: #2563eb;
     }
 
-    .form-checkbox:checked {
-      background-image: url(\\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e\\");
-      border-color: transparent;
-      background-color: currentColor;
-      background-size: 100% 100%;
-      background-position: center;
-      background-repeat: no-repeat;
-    }
-
     .form-checkbox {
       appearance: none;
       color-adjust: exact;
@@ -164,6 +155,15 @@ it('should generate the default classes for the form components', async () => {
       box-shadow: var(--ring-offset-shadow), var(--ring-shadow), var(--box-shadow, 0 0 #0000);
     }
 
+    .form-checkbox:checked {
+      background-image: url(\\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e\\");
+      border-color: transparent;
+      background-color: currentColor;
+      background-size: 100% 100%;
+      background-position: center;
+      background-repeat: no-repeat;
+    }
+
     .form-checkbox:checked:hover {
       border-color: transparent;
       background-color: currentColor;
@@ -174,13 +174,23 @@ it('should generate the default classes for the form components', async () => {
       background-color: currentColor;
     }
 
-    .form-radio:checked {
-      background-image: url(\\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='3'/%3e%3c/svg%3e\\");
+    .form-checkbox:indeterminate {
+      background-image: url(\\"data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 16 16'%3e%3cpath stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e\\");
       border-color: transparent;
       background-color: currentColor;
       background-size: 100% 100%;
       background-position: center;
       background-repeat: no-repeat;
+    }
+
+    .form-checkbox:indeterminate:hover {
+      border-color: transparent;
+      background-color: currentColor;
+    }
+
+    .form-checkbox:indeterminate:focus {
+      border-color: transparent;
+      background-color: currentColor;
     }
 
     .form-radio {
@@ -205,6 +215,15 @@ it('should generate the default classes for the form components', async () => {
       --ring-offset-shadow: 0 0 0 var(--ring-offset-width, 2px) var(--ring-offset-color, #fff);
       --ring-shadow: 0 0 0 calc(2px + var(--ring-offset-width, 2px)) var(--ring-color, #2563eb);
       box-shadow: var(--ring-offset-shadow), var(--ring-shadow), var(--box-shadow, 0 0 #0000);
+    }
+
+    .form-radio:checked {
+      background-image: url(\\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='3'/%3e%3c/svg%3e\\");
+      border-color: transparent;
+      background-color: currentColor;
+      background-size: 100% 100%;
+      background-position: center;
+      background-repeat: no-repeat;
     }
 
     .form-radio:checked:hover {
@@ -457,15 +476,6 @@ it('should be possible to remove the `checkbox` component', async () => {
   ).toMatchInlineSnapshot(`
     "
 
-      - .form-checkbox:checked {
-      -   background-image: url('data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e');
-      -   border-color: transparent;
-      -   background-color: currentColor;
-      -   background-size: 100% 100%;
-      -   background-position: center;
-      -   background-repeat: no-repeat;
-      - }
-      -
       - .form-checkbox {
       -   appearance: none;
       -   color-adjust: exact;
@@ -490,12 +500,40 @@ it('should be possible to remove the `checkbox` component', async () => {
       -   box-shadow: var(--ring-offset-shadow), var(--ring-shadow), var(--box-shadow, 0 0 #0000);
       - }
       -
+      - .form-checkbox:checked {
+      -   background-image: url('data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e');
+      -   border-color: transparent;
+      -   background-color: currentColor;
+      -   background-size: 100% 100%;
+      -   background-position: center;
+      -   background-repeat: no-repeat;
+      - }
+      -
       - .form-checkbox:checked:hover {
       -   border-color: transparent;
       -   background-color: currentColor;
       - }
       -
       - .form-checkbox:checked:focus {
+      -   border-color: transparent;
+      -   background-color: currentColor;
+      - }
+      -
+      - .form-checkbox:indeterminate {
+      -   background-image: url('data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 16 16'%3e%3cpath stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e');
+      -   border-color: transparent;
+      -   background-color: currentColor;
+      -   background-size: 100% 100%;
+      -   background-position: center;
+      -   background-repeat: no-repeat;
+      - }
+      -
+      - .form-checkbox:indeterminate:hover {
+      -   border-color: transparent;
+      -   background-color: currentColor;
+      - }
+      -
+      - .form-checkbox:indeterminate:focus {
       -   border-color: transparent;
       -   background-color: currentColor;
       - }
@@ -524,15 +562,6 @@ it('should be possible to remove the `radio` component', async () => {
     "
 
       -
-      - .form-radio:checked {
-      -   background-image: url('data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='3'/%3e%3c/svg%3e');
-      -   border-color: transparent;
-      -   background-color: currentColor;
-      -   background-size: 100% 100%;
-      -   background-position: center;
-      -   background-repeat: no-repeat;
-      - }
-      -
       - .form-radio {
       -   appearance: none;
       -   color-adjust: exact;
@@ -555,6 +584,15 @@ it('should be possible to remove the `radio` component', async () => {
       -   --ring-offset-shadow: 0 0 0 var(--ring-offset-width, 2px) var(--ring-offset-color, #fff);
       -   --ring-shadow: 0 0 0 calc(2px + var(--ring-offset-width, 2px)) var(--ring-color, #2563eb);
       -   box-shadow: var(--ring-offset-shadow), var(--ring-shadow), var(--box-shadow, 0 0 #0000);
+      - }
+      -
+      - .form-radio:checked {
+      -   background-image: url('data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='3'/%3e%3c/svg%3e');
+      -   border-color: transparent;
+      -   background-color: currentColor;
+      -   background-size: 100% 100%;
+      -   background-position: center;
+      -   background-repeat: no-repeat;
       - }
       -
       - .form-radio:checked:hover {
@@ -925,8 +963,10 @@ it('should be possible to change the icon and icon color of a `checkbox` compone
             DEFAULT: {
               css: {
                 checkbox: {
-                  icon: (iconColor) => `<svg fill="${iconColor}" />`,
-                  iconColor: 'pink',
+                  '&:checked': {
+                    icon: (iconColor) => `<svg fill="${iconColor}" />`,
+                    iconColor: 'pink',
+                  },
                 },
               },
             },
@@ -953,7 +993,9 @@ it('should be possible to change the icon of a `checkbox` component', async () =
             DEFAULT: {
               css: {
                 checkbox: {
-                  icon: `<svg />`,
+                  '&:checked': {
+                    icon: `<svg />`,
+                  },
                 },
               },
             },
@@ -980,7 +1022,9 @@ it('should be possible to change the iconColor of a `checkbox` component', async
             DEFAULT: {
               css: {
                 checkbox: {
-                  iconColor: 'pink',
+                  '&:checked': {
+                    iconColor: 'pink',
+                  },
                 },
               },
             },
@@ -1007,8 +1051,10 @@ it('should be possible to change the icon and icon color of a `radio` component'
             DEFAULT: {
               css: {
                 radio: {
-                  icon: (iconColor) => `<svg fill="${iconColor}" />`,
-                  iconColor: 'pink',
+                  '&:checked': {
+                    icon: (iconColor) => `<svg fill="${iconColor}" />`,
+                    iconColor: 'pink',
+                  },
                 },
               },
             },
@@ -1035,7 +1081,9 @@ it('should be possible to change the icon of a `radio` component', async () => {
             DEFAULT: {
               css: {
                 radio: {
-                  icon: `<svg />`,
+                  '&:checked': {
+                    icon: `<svg />`,
+                  },
                 },
               },
             },
@@ -1062,7 +1110,9 @@ it('should be possible to change the iconColor of a `radio` component', async ()
             DEFAULT: {
               css: {
                 radio: {
-                  iconColor: 'pink',
+                  '&:checked': {
+                    iconColor: 'pink',
+                  },
                 },
               },
             },
@@ -1143,8 +1193,20 @@ it('should pull values from the user config for colors', async () => {
       
       ---
       
+      -   background-color: #fff;
+      -   border-color: #d1d5db;
+      +   background-color: #WHITE;
+      +   border-color: #GRAY300;
+      
+      ---
+      
       -   background-image: url('data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e');
       +   background-image: url('data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='%23WHITE' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e');
+      
+      ---
+      
+      -   background-image: url('data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 16 16'%3e%3cpath stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e');
+      +   background-image: url('data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 16 16'%3e%3cpath stroke='%23WHITE' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e');
       
       ---
       
@@ -1157,13 +1219,6 @@ it('should pull values from the user config for colors', async () => {
       
       -   background-image: url('data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='3'/%3e%3c/svg%3e');
       +   background-image: url('data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='%23WHITE' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='3'/%3e%3c/svg%3e');
-      
-      ---
-      
-      -   background-color: #fff;
-      -   border-color: #d1d5db;
-      +   background-color: #WHITE;
-      +   border-color: #GRAY300;
 
     "
   `)


### PR DESCRIPTION
This PR adds default styles for indeterminate checkboxes using the `:indeterminate` selector, which can be triggered by setting `element.indeterminate = true` on the actual checkbox node using JavaScript.

Implementing this in a sensible way requires a breaking change that no longer lets you set the `icon` or `iconColor` for checkboxes/radios directly under the root `checkbox` or `radio` key. You always have to set it under `&:checked` now.

```js
module.exports = {
  theme: {
    extend: {
      customForms: {
        DEFAULT: {
          css: {
            // Before
            checkbox: {
              iconColor: 'pink',
            },

            // Now
            checkbox: {
              '&:checked': {
                iconColor: 'pink',
              },
            },
          },
        },
      },
    },
  },
}
```

Customizing the indeterminate icon stuff is done the same way as with `:checked`:

```js
module.exports = {
  theme: {
    extend: {
      customForms: {
        DEFAULT: {
          css: {
            checkbox: {
              '&:indeterminate': {
                iconColor: 'pink',
              },
            },
          },
        },
      },
    },
  },
}
```